### PR TITLE
Improve Installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,11 @@
+## Installation
+
+### Mac OS X
+To install pysmFISH on Mac, you must first install open-mpi. This can be done through homebrew: 
+
+`brew install open-mpi`
+
+Then the package can be installed from source via pip3
+
+`pip3 install .`
+

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
         'sympy',
         'loompy',
         'ruamel.yaml',
-        'codecs',
         'h5py',
         'dask',
         'distributed==1.18.3',


### PR DESCRIPTION
- The `codecs` dependency in `setup.py` causes the pip3 installation to fail. Because `codecs` is in the stdlib, it can be safely removed. 
- Added installation instructions for OS X users